### PR TITLE
Add primitive c/CXType_FunctionNoProto parsing

### DIFF
--- a/src/com/phronemophobic/clong/clang.clj
+++ b/src/com/phronemophobic/clong/clang.clj
@@ -186,6 +186,15 @@
        (mapv clang-type->coffi
              (get-argument-types type))
        (clang-type->coffi (c/clang_getResultType type))]
+      
+      ;; This works with 0 arg functions. It will not act as expected if one passes multiple arguments to it.
+      ;; Generally a smell in any API. But used to be common. Added because I happened to test a library that had one of these.
+      ;; to quote https://clang.llvm.org/doxygen/classclang_1_1FunctionNoProtoType.html#details 
+      ;; "Represents a K&R-style 'int foo()' function, which has no information available about its arguments." 
+      c/CXType_FunctionNoProto
+      [:coffi.ffi/fn-no-proto
+       []
+       (clang-type->coffi (c/clang_getResultType type))] 
 
       c/CXType_IncompleteArray
       :coffi.mem/pointer

--- a/src/com/phronemophobic/clong/gen/jna.clj
+++ b/src/com/phronemophobic/clong/gen/jna.clj
@@ -100,6 +100,7 @@
 
         :coffi.ffi/fn Pointer
         ;;com.sun.jna.Callback
+        :coffi.ffi/fn-no-proto Pointer
         
         :coffi.mem/array
         (Class/forName (util/array-type-desc struct-prefix (second t))))
@@ -195,6 +196,15 @@
         (let [->callback
               (callback-maker struct-prefix (nth t 2) (nth t 1))]
           
+          (fn [o]
+            (if (instance? Callback o)
+              o
+              (->callback o))))
+        
+        :coffi.ffi/fn-no-proto
+        (let [->callback
+              (callback-maker struct-prefix (nth t 2) (nth t 1))]
+        
           (fn [o]
             (if (instance? Callback o)
               o


### PR DESCRIPTION
Adds support for parsing `int foo()` like functions as zero-argument functions.

Added because I encountered a library that used one of these and would not parse without it.

I'm pretty certain this is not the best way of doing this. But it's an auto-tool so what can you do.